### PR TITLE
use valid XML files in the tests

### DIFF
--- a/t/xml/mods-2.xml
+++ b/t/xml/mods-2.xml
@@ -9,14 +9,15 @@
     <namePart type="date">1786-1864</namePart>
   </name>
   <typeOfResource/>
-  <originInfo script="Latn">
+  <originInfo>
     <place>
-      <placeTerm type="code" authority="marccountry">xx^</placeTerm>
+      <placeTerm type="code" authority="marccountry">dcu</placeTerm>
+      <placeTerm type="text">Washington, DC</placeTerm>
     </place>
-    <dateIssued>19 mei 1835</dateIssued>
-    <dateIssued encoding="marc">1835^^^^</dateIssued>
-    <issuance/>
-    <frequency/>
+    <publisher>Library of Congress, Cataloging Distribution Service, in collaboration with Follett Software Company</publisher>
+    <dateIssued>2003</dateIssued>
+    <edition>7th ed.</edition>
+    <issuance>monographic</issuance>
   </originInfo>
   <physicalDescription>
     <form authority="gmd">graphic material</form>
@@ -34,7 +35,7 @@
   </subject>
   <location>
     <physicalLocation>CA20</physicalLocation>
-    <shelfLocation>BIB.ARCH.0090.0001</shelfLocation>
+    <shelfLocator>BIB.ARCH.0090.0001</shelfLocator>
   </location>
   <recordInfo>
     <recordContentSource authority="marcorg">UGent</recordContentSource>

--- a/t/xml/mods-3.xml
+++ b/t/xml/mods-3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
 
   <mods ID="a">
     <titleInfo>
@@ -17,7 +17,7 @@
       </place>
       <dateIssued>19 mei 1835</dateIssued>
       <dateIssued encoding="marc">1835^^^^</dateIssued>
-      <issuance/>
+      <issuance>continuing</issuance>
       <frequency/>
     </originInfo>
     <physicalDescription>
@@ -36,7 +36,7 @@
     </subject>
     <location>
       <physicalLocation>CA20</physicalLocation>
-      <shelfLocation>BIB.ARCH.0090.0001</shelfLocation>
+      <shelfLocator>BIB.ARCH.0090.0001</shelfLocator>
     </location>
     <recordInfo>
       <recordContentSource authority="marcorg">UGent</recordContentSource>
@@ -63,7 +63,7 @@
       </place>
       <dateIssued>19 mei 1835</dateIssued>
       <dateIssued encoding="marc">1835^^^^</dateIssued>
-      <issuance/>
+      <issuance>multipart monograph</issuance>
       <frequency/>
     </originInfo>
     <physicalDescription>
@@ -82,7 +82,7 @@
     </subject>
     <location>
       <physicalLocation>CA20</physicalLocation>
-      <shelfLocation>BIB.ARCH.0090.0001</shelfLocation>
+      <shelfLocator>BIB.ARCH.0090.0001</shelfLocator>
     </location>
     <recordInfo>
       <recordContentSource authority="marcorg">UGent</recordContentSource>


### PR DESCRIPTION
Be careful about this. Your module seems to have issues with valid XML files on certain platforms. Also, this patch is not minimal because I lost patience over the originInfo element which just would not validate, so I finally simply copied an example from the spec.